### PR TITLE
V0010

### DIFF
--- a/lib/xmlmunger/version.rb
+++ b/lib/xmlmunger/version.rb
@@ -1,3 +1,3 @@
 module XMLMunger
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end

--- a/xmlmunger.gemspec
+++ b/xmlmunger.gemspec
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 require './lib/xmlmunger/version'
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'xmlmunger'


### PR DESCRIPTION
Requires the `date` lib to avoid this error:

```
[!] There was an error while loading `xmlmunger.gemspec`: uninitialized constant Date
Did you mean?  Data. Bundler cannot continue.
 #  from /Users/username/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/bundler/gems/xmlmunger-74a3b923ed5c/xmlmunger.gemspec:7
 #  -------------------------------------------
 #    s.version     = XMLMunger::VERSION
 >    s.date        = Date.today.to_s
 #    s.summary     = 'Convert XML files into flat hashes with automatic naming via nested paths'
 #  -------------------------------------------
```